### PR TITLE
refactor: restructure the dataset downloader

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,16 +9,16 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 
--   repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
-    hooks:
-      - id: flake8
-
 -   repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:
       - id: black
         args: ["--line-length", "120"]
+
+-   repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8
 
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0

--- a/llm_code_generation_eval/dataset_downloader.py
+++ b/llm_code_generation_eval/dataset_downloader.py
@@ -10,9 +10,10 @@ PATH = Path("data/humanEval.jsonl")
 CURRENT_DIRECTORY = os.getcwd()
 DATA_FILE_PATH = CURRENT_DIRECTORY / PATH
 
-LOG_HANDLERS = []
-LOG_HANDLERS.append(logging.FileHandler("llm_code_generation_eval.log"))
-LOG_HANDLERS.append(logging.StreamHandler())
+LOG_HANDLERS = [
+    logging.FileHandler("llm_code_generation_eval.log"),
+    logging.StreamHandler(),
+]
 
 logging.basicConfig(
     level=logging.INFO,
@@ -24,13 +25,8 @@ logging.basicConfig(
 def download_dataset():
     logger = logging.getLogger(__name__)
     dataset = load_dataset(HUMAN_EVAL_DATASET)
-    print(f"Data file path: {DATA_FILE_PATH}")
     with open(DATA_FILE_PATH, "wb") as csv_file:
         for row in dataset["test"]:
             json_row = (json.dumps(row) + "\n").encode("utf-8")
             csv_file.write(json_row)
     logger.info("Complete downloading the dataset")
-
-
-if __name__ == "__main__":
-    download_dataset()

--- a/llm_code_generation_main.py
+++ b/llm_code_generation_main.py
@@ -1,0 +1,4 @@
+from llm_code_generation_eval.dataset_downloader import download_dataset
+
+if __name__ == "__main__":
+    download_dataset()


### PR DESCRIPTION
In this commit a new entrypoint to run the project is created in `llm_code_generation_main.py`. 

The dataset_downloader.py is now refactored into the python module `llm_code_generation_eval` and can be accessed in import as `from llm_code_generation_eval.dataset_downloader import download_dataset`. 

The `.pre-commit-config.yaml` file is updated to have black reformat the file before flake8 checks are passed.