### PR TITLE
refactor: add a test case for the dataset downloader

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,19 +9,19 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 
--   repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-      - id: black
-        args: ["--line-length", "120"]
-
--   repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
-    hooks:
-      - id: flake8
-
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
+
+-   repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black
+        args: ["--line-length", "79"]
+
+-   repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8

--- a/tests/test_dataset_downloader.py
+++ b/tests/test_dataset_downloader.py
@@ -1,0 +1,25 @@
+import json
+from typing import Dict, List
+from unittest import TestCase
+
+from llm_code_generation_eval import dataset_downloader
+
+
+class TestDataSetDownloader(TestCase):
+    def test_download_dataset(self):
+        dataset_downloader.download_dataset()
+        # Check to see if the file exists in that location
+        file_location = dataset_downloader.DATA_FILE_PATH
+        self.assertTrue(file_location.exists(), "File Exists")
+        # Check to see if the content in the file has correct structure
+        valid_keys: List[str] = [
+            "task_id",
+            "prompt",
+            "canonical_solution",
+            "test",
+            "entry_point",
+        ]
+        with open(file_location, "r") as csv_file:
+            read_line: Dict[str, str] = json.loads(csv_file.readline())
+            is_keys: bool = all(key in read_line.keys() for key in valid_keys)
+            self.assertTrue(is_keys, "All keys are valid")


### PR DESCRIPTION
In this commit the dataset downloader test case is checked in. As a result of that a new data folder and .gitkeep file is checked in. Ordering of the pre-commit hooks updated, to have imports sorted first before reformatting.